### PR TITLE
Escape nested HTML in HTML interpreter

### DIFF
--- a/excel.test.ts
+++ b/excel.test.ts
@@ -121,4 +121,15 @@ describe('Excel.toHtml() end usage tests', () => {
         expect(excel.toHtml(rule8String, true)).toEqual(html(rule8Html));
     });
 
+    test('Excel.toHtml() should escape nested html', () => {
+        expect(excel.toHtml(`TMPL('<i class="pi pi-plus"></i>')`, true)).toEqual(html(`
+            <div>
+                <span class="function">TMPL</span>
+                <span class="paren-deep-1">(</span>
+                <span class="value">'&lt;i class=&quot;pi pi-plus&quot;&gt;&lt;/i&gt;'</span>
+                <span class="paren-deep-1">)</span>
+            </div>
+        `));
+    });
+
 });

--- a/excel.test.ts
+++ b/excel.test.ts
@@ -117,6 +117,21 @@ describe('Excel.toHtml() end usage tests', () => {
         expect(excel.toHtml("EQ(", true)).toEqual(`<div><span class="function">EQ</span><span class="paren-deep-1">(</span></div>`);
     });
 
+    test('toHtml(tree, flexible=true) should parse complete formula', () => {
+        expect(excel.toHtml(`EQ(VALUE("#firstName"), "John")`, true)).toEqual(html(`
+            <div>
+                <span class="function">EQ</span>
+                <span class="paren-deep-1">(</span>
+                <span class="function">VALUE</span>
+                <span class="paren-deep-2">(</span>
+                <span class="value">'#firstName'</span>
+                <span class="paren-deep-2">)</span>,
+                <span class="value">'John'</span>
+                <span class="paren-deep-1">)</span>
+            </div>
+        `));
+    });
+
     test('Excel.toHtml() parent deeps should loop from 0 to max deep level', () => {
         expect(excel.toHtml(rule8String, true)).toEqual(html(rule8Html));
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "excel-formula-parser",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "he": "^1.2.0"
+      },
       "devDependencies": {
         "@types/jest": "^28.1.4",
         "jest": "^28.1.2",
@@ -1850,6 +1853,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/html-escaper": {
@@ -5075,6 +5086,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "ts-jest": "^28.0.5",
     "ts-node": "^10.8.2",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "he": "^1.2.0"
   }
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,4 +1,5 @@
 import { ASTFunctionNode, ASTNode, ASTPathNode, ASTValueNode, ASTVariableNode } from './node';
+import * as he from 'he';
 
 /* Base class Interpreter, this contains common methods for interpreters */
 abstract class InterpreterBase {
@@ -29,7 +30,8 @@ abstract class InterpreterBase {
   protected visitValue(item: string): string {
 
     if (typeof item === 'string') {
-      return `'${String(item)}'`;
+      const escaped_item: string = he.escape(item.toString());
+      return `'${String(escaped_item)}'`;
     }
 
     return item;

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -71,7 +71,7 @@ export class Lexer {
     }
 
     // Tokenize VALUE token type
-    const pattern = (this.flexible) ? /^(\'.+\'?|\".+\"?|\[.+\]?|\d+\.?\d*)/ : /^(\'.+?\'|\".+?\"|\[.+?\]|\d+\.?\d*)/;
+    const pattern = (this.flexible) ? /^(\'[^\']+\'?|\"[^\"]+\"?|\[[^\[\]]\]?|\d+\.?\d*)/ : /^(\'.+?\'|\".+?\"|\[.+?\]|\d+\.?\d*)/;
     const value = this.getCurrentLine().match(pattern);
     if (value) {
       this.advance(value[0].length);


### PR DESCRIPTION
Formula: `TMPL('<i class="pi pi-plus"></i>')`

Actual result: Rendered HTML looks like this
<img width="346" alt="image" src="https://github.com/cwayfinder/formula-parser/assets/355902/30ce9ff2-7cca-407f-9f77-111122a58099">

Expected result:
<img width="347" alt="image" src="https://github.com/cwayfinder/formula-parser/assets/355902/4d338b00-4e27-4657-80b3-017f3aa5bcf8">
